### PR TITLE
Fix readme typo. Add graphiql.html to setup.py.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 A [Tornado](http://www.tornadoweb.org/) boilerplate for [Graphene](http://graphene-python.org/) with subscriptions.
 
-A very easy to use, full extensible Tornado Web Server Integration with Graphene to make serving GraphQL APIs, including Websocket subscriptions, as easy as defining your schema.
+A very easy to use, fully extensible Tornado Web Server Integration with Graphene to make serving GraphQL APIs, including Websocket subscriptions, as easy as defining your schema.
 
 With TornadoQL, exposing a graphene schema as a GraphQL API takes two imports and one line of code. You can also make that API part of a larger application by simply adding to the GraphQL endpoints and Tornado application settings before calling start. Getting your own API-only server up is as simple as defining a Graphene schema and the following code:
 

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,8 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3.4'
     ],
-    install_requires=['tornado', 'graphene', 'rx']
+    install_requires=['tornado', 'graphene', 'rx'],
+    package_data={
+        'tornadoql': ['static/graphiql.html'],
+    }
 )


### PR DESCRIPTION
Hi Ilya,
The setup.py wasn't including the html file, which has been fixed. Also fixed a typo in the readme.